### PR TITLE
Fix typo(us.jubatu.stat -> us.jubat.stat)

### DIFF
--- a/src/main/java/us/jubat/stat/ConfigData.java
+++ b/src/main/java/us/jubat/stat/ConfigData.java
@@ -26,7 +26,7 @@
 // *** DO NOT EDIT ***
 
 
-package us.jubatu.stat;
+package us.jubat.stat;
 
 import org.msgpack.MessagePack;
 import org.msgpack.annotation.Message;


### PR DESCRIPTION
Fixed a wrong package statement.
