### PR TITLE
Add tests for setLabel, getLabels and deleteLabel

### DIFF
--- a/src/test/java/us/jubat/classifier/ClassifierClientTest.java
+++ b/src/test/java/us/jubat/classifier/ClassifierClientTest.java
@@ -92,6 +92,19 @@ public class ClassifierClientTest extends JubatusClientTest {
 	}
 
 	@Test
+	public void testLabels() {
+		assertThat(client.setLabel("label"), is(true));
+		Map<String, Integer> labels = client.getLabels();
+		assertThat(labels, is(notNullValue()));
+		assertThat(labels.size(), is(1));
+		assertThat(labels.get("label"), is(0));
+		assertThat(client.deleteLabel("label"), is(true));
+		labels = client.getLabels();
+		assertThat(labels, is(notNullValue()));
+		assertThat(labels.size(), is(0));
+	}
+
+	@Test
 	public void testGet_status() {
 		Map<String, Map<String, String>> status = client.getStatus();
 		assertThat(status, is(notNullValue()));


### PR DESCRIPTION
This patch is a part of https://github.com/jubatus/jubatus_core/pull/272

Currently, ``set_label``, ``get_labels``, ``delete_label`` are not tested.
I added tests about the above RPC and modified it to follow the new ``get_labels`` RPC signature.