### PR TITLE
fix status key name in classifier/regression test (refs #41)

### DIFF
--- a/src/test/java/us/jubat/classifier/ClassifierClientTest.java
+++ b/src/test/java/us/jubat/classifier/ClassifierClientTest.java
@@ -128,13 +128,13 @@ public class ClassifierClientTest extends JubatusClientTest {
 		Map<String, Map<String, String>> before = client.getStatus();
 		String node_name = (String) before.keySet().iterator().next();
 		assertThat(before.get(node_name).get("num_classes"), is(not("0")));
-		assertThat(before.get(node_name).get("num_features_diff"), is(not("0")));
+		assertThat(before.get(node_name).get("num_features"), is(not("0")));
 
 		client.clear();
 
 		Map<String, Map<String, String>> after = client.getStatus();
 		assertThat(after.get(node_name).get("num_classes"), is("0"));
-		assertThat(after.get(node_name).get("num_features_diff"), is("0"));
+		assertThat(after.get(node_name).get("num_features"), is("0"));
 	}
 
 	@Test

--- a/src/test/java/us/jubat/regression/RegressionClientTest.java
+++ b/src/test/java/us/jubat/regression/RegressionClientTest.java
@@ -110,13 +110,13 @@ public class RegressionClientTest extends JubatusClientTest {
 		Map<String, Map<String, String>> before = client.getStatus();
 		String node_name = (String) before.keySet().iterator().next();
 		assertThat(before.get(node_name).get("num_classes"), is(not("0")));
-		assertThat(before.get(node_name).get("num_features_diff"), is(not("0")));
+		assertThat(before.get(node_name).get("num_features"), is(not("0")));
 
 		client.clear();
 
 		Map<String, Map<String, String>> after = client.getStatus();
 		assertThat(after.get(node_name).get("num_classes"), is("0"));
-		assertThat(after.get(node_name).get("num_features_diff"), is("0"));
+		assertThat(after.get(node_name).get("num_features"), is("0"));
 	}
 
 	@Test


### PR DESCRIPTION
This PR partially reverts changes in https://github.com/jubatus/jubatus-java-client/pull/41, as https://github.com/jubatus/jubatus/pull/1153 was reverted in https://github.com/jubatus/jubatus/pull/1193.

CI fails due to this error. http://ci.jubat.us/job/jubatus-java-client/34/default/testReport/